### PR TITLE
Revert "Add cfp.rubykaigi.org"

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -223,13 +223,4 @@ http {
       proxy_pass http://ruby-sapporo.github.io;
     }
   }
-
- server {
-    listen <%= ENV["PORT"] %>;
-    server_name cfp.rubykaigi.org;
-    location / {
-      proxy_set_header Host $host;
-      proxy_pass http://rubykaigi-cfp.herokuapp.com;
-    }
-  }
 }


### PR DESCRIPTION
This reverts commit c97f26cdfeb21b0d644e4b7283f5622966b2687a.
We pointed cfp.rubykaigi.org to Heroku directly with CNAME.