### PR TITLE
Route to Kansai RubyKaigi 2017

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -39,6 +39,10 @@ http {
 #       rewrite ^/oedo03(.*)$ http://oedo03.herokuapp.com/oedo03$1 permanent;
     }
 
+    location ~ ^/kansai2017(.*) {
+      proxy_pass http://rubykansai.github.io;
+    }
+
     #
     # kansai 06, y10y
     #


### PR DESCRIPTION
関西Ruby会議2017 の proxy_pass を追加しました。
https://rubykansai.github.io/kansai2017/