### PR TITLE
move from linode to github pages

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -183,33 +183,26 @@ http {
       rewrite ^(.*)$ http://jp.rubyist.net/RubyKaigi$rubykaigi_year permanent;
     }
 
-    location ~ ^/2006(.*) {
-        proxy_pass http://linode.rubykaigi.org;
-    }
-
-    location ~ ^/2007(.*) {
-        proxy_pass http://linode.rubykaigi.org;
-    }
-
-    location ~ ^/2008(.*) {
-        proxy_pass http://linode.rubykaigi.org;
+    location ~ ^/(200[6-8])(.*) {
+        set $rubykaigi_year $1;
+        rewrite ^(.*)$ http://jp.rubyist.net/RubyKaigi$rubykaigi_year permanent;
     }
 
     location ~ ^/2009(.*) {
-        proxy_pass http://linode.rubykaigi.org;
+        proxy_pass http://2009-2011.rubykaigi.org;
     }
 
     location ~ ^/2010(.*) {
-        proxy_pass http://linode.rubykaigi.org;
+        proxy_pass http://2009-2011.rubykaigi.org;
     }
 
     location ~ ^/2011(.*) {
-        proxy_pass http://linode.rubykaigi.org;
+        proxy_pass http://2009-2011.rubykaigi.org;
     }
 
     location ~ ^/2012(.*) {
         # for 404 kaigi not found
-        proxy_pass http://linode.rubykaigi.org;
+        proxy_pass http://2009-2011.rubykaigi.org;
     }
 
     location ~ ^/assets/(20[1-9][3-9]) {
@@ -238,15 +231,15 @@ http {
     }
 
     location ~ ^/\.2006(.*) {
-        proxy_pass http://linode.rubykaigi.org;
+        proxy_pass http://2009-2011.rubykaigi.org;
     }
 
     location ~ ^/\.2007(.*) {
-        proxy_pass http://linode.rubykaigi.org;
+        proxy_pass http://2009-2011.rubykaigi.org;
     }
 
     location ~ ^/\.2008(.*) {
-        proxy_pass http://linode.rubykaigi.org;
+        proxy_pass http://2009-2011.rubykaigi.org;
     }
 
     # current rubykaigi
@@ -255,11 +248,11 @@ http {
     }
 
     location ~* /([0-9][0-9][0-9][0-9])?(images|javascripts|stylehseets)/ {
-        proxy_pass http://linode.rubykaigi.org;
+        proxy_pass http://2009-2011.rubykaigi.org;
     }
 
     location ~* .ico$ {
-        proxy_pass http://linode.rubykaigi.org;
+        proxy_pass http://2009-2011.rubykaigi.org;
     }
   }
 


### PR DESCRIPTION
linode.rubykaigi.org を捨てて github pages (https://github.com/ruby-no-kai/rubykaigi-static) を使うようにするための修正です。