### PR TITLE
Change redirect url for sponsors from 2017 to 2018

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -281,7 +281,7 @@ http {
     listen <%= ENV["PORT"] %>;
     server_name sponsorship.rubykaigi.org;
     location / {
-      return 302 https://docs.google.com/a/rubykaigi.org/forms/d/e/1FAIpQLSdZtIZmWIUtgQelPAJ0a943KWyqcHzbakx9kO3QZ98BIhJiCg/viewform;
+      return 302 https://docs.google.com/forms/d/e/1FAIpQLSfkgH_vh_qu-KJN-w7zJOKtHKginbTSB_8fqzOlcqm9wOJtxw/viewform;
     }
   }
 }


### PR DESCRIPTION
cf.) #34 

## やったこと

https://github.com/ruby-no-kai/rubykaigi2018/issues/18#issuecomment-358261897
にまつわるタスクです。
2017 年用のフォーム URL にリダイレクトされていたのを 2018 年用のフォームに変更しました

## みてほしいこと

URL が微妙に違うのですが、フォームとしては
https://docs.google.com/forms/d/e/1FAIpQLSfkgH_vh_qu-KJN-w7zJOKtHKginbTSB_8fqzOlcqm9wOJtxw/viewform
で良いのですよね？