### PR TITLE
Add server_name setting to redirect from sponsorships

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -276,10 +276,10 @@ http {
     }
   }
 
-  # sponsorship application form for rubykaigi 2017.
+  # sponsorship application form for rubykaigi 2018.
   server {
     listen <%= ENV["PORT"] %>;
-    server_name sponsorship.rubykaigi.org;
+    server_name sponsorship.rubykaigi.org sponsorships.rubykaigi.org;
     location / {
       return 302 https://docs.google.com/forms/d/e/1FAIpQLSfkgH_vh_qu-KJN-w7zJOKtHKginbTSB_8fqzOlcqm9wOJtxw/viewform;
     }


### PR DESCRIPTION
cf.) https://github.com/ruby-no-kai/rubykaigi2018/issues/34

## やったこと

- コメントアウトの変更漏れ修正
  - 前回の PR のときにやっておけばよかったです...
- sponsorships でもリダイレクトできるような変更
  - 2 ストライク 3 アウト制を信じているので、この程度ならかっこよく reg exp を使わずそのままで行く

## 見てほしいこと

- nginx.conf 全然触ったこと無いので、これであってるか見てほしいです