### PR TITLE
Moving past Kaigis from Heroku to pages

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -299,24 +299,24 @@ http {
     }
 
     location ~ ^/2013(.*) {
-        proxy_pass http://rubykaigi2013.herokuapp.com;
+        proxy_pass http://2009-2011.rubykaigi.org;
     }
 
     location ~ ^/2014(.*) {
-        proxy_pass http://rubykaigi2014.herokuapp.com;
+        proxy_pass http://2009-2011.rubykaigi.org;
     }
 
     location ~ ^/2015(.*) {
-        proxy_pass http://rubykaigi2015.herokuapp.com;
+        proxy_pass http://2009-2011.rubykaigi.org;
     }
 
     location ~ ^/2016(.*) {
-        proxy_pass http://rk2016.herokuapp.com;
+        proxy_pass http://2009-2011.rubykaigi.org;
     }
 
     location ~ ^/2017(.*) {
         include force_https.conf;
-        proxy_pass http://rubykaigi2017.herokuapp.com;
+        proxy_pass http://2009-2011.rubykaigi.org;
     }
 
     location ~ ^/2018(.*) {

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -281,37 +281,12 @@ http {
         proxy_pass http://2009-2011.rubykaigi.org;
     }
 
-    location ~ ^/2010(.*) {
-        proxy_pass http://2009-2011.rubykaigi.org;
-    }
-
-    location ~ ^/2011(.*) {
-        proxy_pass http://2009-2011.rubykaigi.org;
-    }
-
-    location ~ ^/2012(.*) {
-        # for 404 kaigi not found
+    location ~ ^/201[0-6](.*) {
         proxy_pass http://2009-2011.rubykaigi.org;
     }
 
     location ~ ^/assets/(20[1-9][3-9]) {
         rewrite ^/assets/(20[1-9][3-9])(.*)$ http://rubykaigi$1.herokuapp.com/assets/$1$2;
-    }
-
-    location ~ ^/2013(.*) {
-        proxy_pass http://2009-2011.rubykaigi.org;
-    }
-
-    location ~ ^/2014(.*) {
-        proxy_pass http://2009-2011.rubykaigi.org;
-    }
-
-    location ~ ^/2015(.*) {
-        proxy_pass http://2009-2011.rubykaigi.org;
-    }
-
-    location ~ ^/2016(.*) {
-        proxy_pass http://2009-2011.rubykaigi.org;
     }
 
     location ~ ^/2017(.*) {


### PR DESCRIPTION
更新の止まって久しい RubyKaigi 2013, 2014, 2016, 2017 の各サイトを Heroku から rubykaigi-static に切り替えたいです。rubykaigi-static には push 済みです。

ただし、2015だけは、僕の手元で `bundle e rake build`して生成されたものを rubykaigi-static に置いてみたところ、scheduleから 各 presentation へのリンクがぶっ壊れていて、
https://2009-2011.rubykaigi.org/2015/schedule/
よくわかんないのでいったんそのままにしてあります。
