### PR TITLE
Redirect oedo02 directly from the router rather than bypassing GH Pages

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -101,6 +101,10 @@ http {
     }
     add_header Content-Security-Policy-Report-Only "$csp_policy";
 
+    location ~ ^/oedo02(.*) {
+      return 301 https://magazine.rubyist.net/articles/0039/0039-MetPragdaveAtAsakusarb.html;
+    }
+
     location ~ ^/oedo03(.*) {
       proxy_pass http://oedo03.herokuapp.com;
 #       rewrite ^/oedo03(.*)$ http://oedo03.herokuapp.com/oedo03$1 permanent;


### PR DESCRIPTION
oedo02のリダイレクト先を追加するパッチです。

## 経緯など
もともとoedo02のイベント自体のサイトは存在していなくて、たなべさんが書いたるびまの記事が大江戸02と呼ばれるイベントの公式サイトということになっていました。

で、そのためのリダイレクトをここのHTML内でやってたんですけど、このHTMLが長らく更新されてなくて旧るびまURLのままになっていたようです。 https://github.com/ruby-no-kai/regional.rubykaigi.org/blob/3606496af0c9702c4fd6b9daef1bcebfcc57b12d/oedo02/index.html

というのが、今晩のAsakusa.rbのmeetupで発覚して、しかしどうせリダイレクトしてるだけだったらGH Pagesをかまさずにrko-routerに直接書けばよくね？という話になったのでした。

……って書いてるうちに[こっちはこっちで](https://github.com/ruby-no-kai/regional.rubykaigi.org/pull/119)なんか直しちゃったようですけど、まあしかしやっぱりGH Pagesのほうはそもそも不要になるんじゃないかな……。

/cc @takkanm @kakutani