### PR TITLE
oedo04 is HTTPS only now

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -200,7 +200,7 @@ http {
     }
 
     location ~ ^/oedo04(.*) {
-    proxy_pass http://oedo04.herokuapp.com;
+    proxy_pass https://oedo04.herokuapp.com;
     }
 
     location ~ ^/hamamatsu01(.*) {


### PR DESCRIPTION
現状、 https://regional.rubykaigi.org/oedo04/ にアクセスするといつの間にか "Not Found" ってなるようになってたようで、でもproxy先の https://oedo04.herokuapp.com/ を直接見るとちゃんと動いてそうで、最近やったことと言ったらアプリを heroku-18 stackに上げたことぐらいなんだけど、それに伴ってHeroku側がHTTPSになったはずなので、こっちも https://... って書いておかなきゃいけないのかな？というやつです。

いずれにしろ、すぐにでもstaticに持っていきたいのでもうこの際そっちを進めちゃえばいいんじゃないかな、とは思いつつ、壊れた状態のものはいったん直してみたいので、これでどうでしょうか？的なパッチを投げてみます。