### PR TITLE
route :oedo04, :to => regional-gh

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -199,10 +199,6 @@ http {
     proxy_pass https://kawasakirb.github.io;
     }
 
-    location ~ ^/oedo04(.*) {
-    proxy_pass https://oedo04.herokuapp.com;
-    }
-
     location ~ ^/hamamatsu01(.*) {
     proxy_pass http://rubykaigi-hamamatsu.s3-website-ap-northeast-1.amazonaws.com;
     }


### PR DESCRIPTION
https://github.com/ruby-no-kai/regional.rubykaigi.org/pull/122 でoedo04のHerokuアプリをstatic化したので、そっちにルーティングするようにします。