### PR TITLE
route :oedo03, :to => regional-gh

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -105,11 +105,6 @@ http {
       return 301 https://magazine.rubyist.net/articles/0039/0039-MetPragdaveAtAsakusarb.html;
     }
 
-    location ~ ^/oedo03(.*) {
-      proxy_pass http://oedo03.herokuapp.com;
-#       rewrite ^/oedo03(.*)$ http://oedo03.herokuapp.com/oedo03$1 permanent;
-    }
-
     location ~ ^/osaka02(.*) {
       proxy_pass https://rubykansai.github.io;
     }


### PR DESCRIPTION
https://github.com/ruby-no-kai/regional.rubykaigi.org/pull/121 がマージされたので、今までHerokuに向いてたoedo03をstaticなHTMLページから返すようにします(とっくにやったと思ってたら作業が漏れてたようです)。

before: http://oedo03.herokuapp.com/oedo03
after: http://regional-gh.rubykaigi.org/oedo03