### PR TITLE
Force HTTPS on /2006.. /2009

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -279,6 +279,7 @@ http {
     add_header Content-Security-Policy-Report-Only "$csp_policy";
 
     location ~ ^/200[6-9] {
+        include force_https.conf;
         proxy_pass http://2009-2011.rubykaigi.org;
     }
 


### PR DESCRIPTION
大江戸09に向けて、2006 - 2009 の各サイトをforce_https化したいです。いちおう全ページざっと確認したつもりで、特にエラーらしいエラーは無さそうな気がしています(デプロイしたらもっかい確認はします)。

以上の対応で、過去のRubyKaigiのサイトは全てHTTPSでしか読まれないようになったはずです。