### PR TITLE
ルーティングされてなさそうな .2006 と .2008 の削除

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -320,10 +320,6 @@ http {
         proxy_pass http://2009-2011.rubykaigi.org;
     }
 
-    location ~ ^/\.2008(.*) {
-        proxy_pass http://2009-2011.rubykaigi.org;
-    }
-
     # current rubykaigi
     location = / {
         return 302 https://rubykaigi.org/2021-takeout;

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -312,10 +312,6 @@ http {
         proxy_pass http://rubykaigi2019.herokuapp.com;
     }
 
-    location ~ ^/\.2006(.*) {
-        proxy_pass http://2009-2011.rubykaigi.org;
-    }
-
     location ~ ^/\.2007(.*) {
         proxy_pass http://2009-2011.rubykaigi.org;
     }


### PR DESCRIPTION
.2008 は https://github.com/ruby-no-kai/rubykaigi-static/pull/55 で削除されました。

.2006 は 5a2b9fd805b6b67e9e49d85e998ce6eca7af6531 で Linode に置いてあった時点では何か存在してたのかもしれませんが、ruby-kaigi-static のリポジトリ上ではそういう名前のディレクトリが存在した歴史はなさそうだし、リポジトリ内を `git grep` してみても、ここのファイルが参照されてたり何かリクエストが飛びそうだったりはしなさそうです。
