### PR TITLE
^/assets/(20[1-9][3-9]) っていう使われてないrewriteの削除

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -283,10 +283,6 @@ http {
         proxy_pass http://2009-2011.rubykaigi.org;
     }
 
-    location ~ ^/assets/(20[1-9][3-9]) {
-        rewrite ^/assets/(20[1-9][3-9])(.*)$ http://rubykaigi$1.herokuapp.com/assets/$1$2;
-    }
-
     location ~ ^/201[0-9](.*) {
         include force_https.conf;
         proxy_pass http://2009-2011.rubykaigi.org;


### PR DESCRIPTION
0385d95f039d210bf10c962925ce0612a38182c7 の時点では何やらいろいろあったようなんですが、現時点ではそういうURLへのリクエストは来なそうだし、仮に来たところでもう herokuapp.com 上の各年のアプリが生きてるとは限らなそうだし、これはもう死んでるルールでしょう。