### PR TITLE
Redirect 200[6-8].rubykaigi.org  =>  rubykaigi-static

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -264,7 +264,8 @@ http {
 
     if ($host ~* ^(\d+)\.(.*)) {
       set $rubykaigi_year $1;
-      rewrite ^(.*)$ http://jp.rubyist.net/RubyKaigi$rubykaigi_year permanent;
+      include force_https.conf;
+      return 301 http://2009-2011.rubykaigi.org/$rubykaigi_year/$request_uri;
     }
   }
 


### PR DESCRIPTION
2006.rubykaigi.org とかにアクセスすると、jp.rubyist.net に飛んでいってしまう設定が残ってるんですが、これを rubykaigi-static に飛ぶように修正しています。
実際にこういうリクエストが今でもあるのかどうかは知りません、というかたぶん無さそうな気はしてますけど。