### PR TITLE
Archive 2021-takeout

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -304,8 +304,7 @@ http {
 
     location /2021-takeout {
         include force_https.conf;
-        # FIXME: We have to rename our heroku app later
-        proxy_pass http://rubykaigi2019.herokuapp.com;
+        proxy_pass http://2009-2011.rubykaigi.org;
     }
 
     location ~ ^/\.2007(.*) {


### PR DESCRIPTION
2021-takeoutのサイトを、https://github.com/ruby-no-kai/rubykaigi-static/pull/58 でアーカイブしたやつに切り替えます。