### PR TITLE
Add CloudFront distribution for App Runner deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .terraform/
+node_modules/
+tf/cf_functions/src/*.js
+tf/cf_functions/src/*.js.map

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ COPY config/nginx.conf.erb /etc/nginx/nginx.conf.erb
 COPY config/force_https.conf /etc/nginx/force_https.conf
 RUN /docker-entrypoint.d/rko-router.sh
 RUN nginx -c /etc/nginx/nginx.conf
+ENV PRIMARY_HOST rko-router.rubykaigi.org
 EXPOSE 8080

--- a/tf/.terraform.lock.hcl
+++ b/tf/.terraform.lock.hcl
@@ -19,3 +19,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:b121595f53c85bdbb59504b255628d219c42586cb258f0d4cf8a532a98f766e5",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.1.1"
+  hashes = [
+    "h1:71sNUDvmiJcijsvfXpiLCz0lXIBSsEJjMxljt7hxMhw=",
+    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
+    "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
+    "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fdd792a626413502e68c195f2097352bdc6a0df694f7df350ed784741eb587e",
+    "zh:976bbaf268cb497400fd5b3c774d218f3933271864345f18deebe4dcbfcd6afa",
+    "zh:b21b78ca581f98f4cdb7a366b03ae9db23a73dfa7df12c533d7c19b68e9e72e5",
+    "zh:b7fc0c1615dbdb1d6fd4abb9c7dc7da286631f7ca2299fb9cd4664258ccfbff4",
+    "zh:d1efc942b2c44345e0c29bc976594cb7278c38cfb8897b344669eafbc3cddf46",
+    "zh:e356c245b3cd9d4789bab010893566acace682d7db877e52d40fc4ca34a50924",
+    "zh:ea98802ba92fcfa8cf12cbce2e9e7ebe999afbf8ed47fa45fc847a098d89468b",
+    "zh:eff8872458806499889f6927b5d954560f3d74bf20b6043409edf94d26cd906f",
+  ]
+}

--- a/tf/acm.tf
+++ b/tf/acm.tf
@@ -1,0 +1,5 @@
+data "aws_acm_certificate" "use1-wild-rk-o" {
+  provider    = aws.use1
+  domain      = "rubykaigi.org"
+  most_recent = true
+}

--- a/tf/aws.tf
+++ b/tf/aws.tf
@@ -3,4 +3,10 @@ provider "aws" {
   allowed_account_ids = ["005216166247"]
 }
 
+provider "aws" {
+  alias               = "use1"
+  region              = "us-east-1"
+  allowed_account_ids = ["005216166247"]
+}
+
 data "aws_caller_identity" "current" {}

--- a/tf/cf_functions/package-lock.json
+++ b/tf/cf_functions/package-lock.json
@@ -1,0 +1,46 @@
+{
+  "name": "cf_functions",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@types/aws-cloudfront-function": "^1.0.2",
+        "typescript": "^4.8.3"
+      }
+    },
+    "node_modules/@types/aws-cloudfront-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/aws-cloudfront-function/-/aws-cloudfront-function-1.0.2.tgz",
+      "integrity": "sha512-srgwZoYI94Pwe1/vtMANK7Z2cfuXRuLda34QlFKf5eAcrXs6goXD4gbE9Kh/RFYtg76Aoi0JBdU1xzBzxzwyUw==",
+      "dev": true
+    },
+    "node_modules/typescript": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  },
+  "dependencies": {
+    "@types/aws-cloudfront-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/aws-cloudfront-function/-/aws-cloudfront-function-1.0.2.tgz",
+      "integrity": "sha512-srgwZoYI94Pwe1/vtMANK7Z2cfuXRuLda34QlFKf5eAcrXs6goXD4gbE9Kh/RFYtg76Aoi0JBdU1xzBzxzwyUw==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true
+    }
+  }
+}

--- a/tf/cf_functions/package.json
+++ b/tf/cf_functions/package.json
@@ -1,0 +1,6 @@
+{
+  "devDependencies": {
+    "@types/aws-cloudfront-function": "^1.0.2",
+    "typescript": "^4.8.3"
+  }
+}

--- a/tf/cf_functions/src/viewreq.ts
+++ b/tf/cf_functions/src/viewreq.ts
@@ -1,0 +1,16 @@
+function handler(
+  event: AWSCloudFrontFunction.Event
+): AWSCloudFrontFunction.Request {
+  const { request } = event;
+
+  request.headers["x-rko-host"] = request.headers["host"];
+
+  const fp = request.headers["cloudfront-forwarded-proto"]?.value;
+  if (fp === "https" || fp === "HTTPS") {
+    request.headers["x-rko-xfp"] = { value: "https" };
+  } else {
+    request.headers["x-rko-xfp"] = { value: "http" };
+  }
+
+  return request;
+}

--- a/tf/cf_functions/tsconfig.json
+++ b/tf/cf_functions/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "lib": ["es2015"],
+    "sourceMap": true,
+    "strict": true,
+    "allowSyntheticDefaultImports": true
+  }
+}
+

--- a/tf/cloudfront.tf
+++ b/tf/cloudfront.tf
@@ -101,7 +101,7 @@ resource "aws_cloudfront_cache_policy" "rko-router-default" {
     headers_config {
       header_behavior = "whitelist"
       headers {
-        items = ["x-rko-host", "x-rko-xfp"]
+        items = ["x-rko-host", "x-rko-xfp", "cloudfront-forwarded-proto"]
       }
     }
     query_strings_config {

--- a/tf/cloudfront.tf
+++ b/tf/cloudfront.tf
@@ -1,0 +1,136 @@
+resource "aws_cloudfront_distribution" "rko-router" {
+  enabled         = true
+  is_ipv6_enabled = true
+  price_class     = "PriceClass_All"
+  comment         = "rko-router"
+
+  aliases = [
+    "rko-router.rubykaigi.org",
+
+    "rubykaigi.org",
+
+    "2006.rubykaigi.org",
+    "2007.rubykaigi.org",
+    "2008.rubykaigi.org",
+    "j.rubykaigi.org",
+    "regional.rubykaigi.org",
+    "sapporo.rubykaigi.org",
+    "sponsorship.rubykaigi.org",
+    "www.rubykaigi.org",
+    "yami.rubykaigi.org",
+  ]
+
+  viewer_certificate {
+    acm_certificate_arn      = data.aws_acm_certificate.use1-wild-rk-o.arn
+    minimum_protocol_version = "TLSv1.2_2021"
+    ssl_support_method       = "sni-only"
+  }
+
+  logging_config {
+    include_cookies = false
+    bucket          = "rk-aws-logs.s3.amazonaws.com"
+    prefix          = "cf/rko-router.rubykaigi.org/"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  origin {
+    origin_id   = "rko-router-apprunner"
+    domain_name = replace(aws_apprunner_service.rko-router.service_url, "https://", "")
+
+    custom_origin_config {
+      http_port                = 80
+      https_port               = 443
+      origin_protocol_policy   = "https-only"
+      origin_ssl_protocols     = ["TLSv1.2"]
+      origin_keepalive_timeout = 30
+      origin_read_timeout      = 35
+    }
+
+    origin_shield {
+      enabled              = true
+      origin_shield_region = "ap-northeast-1"
+    }
+  }
+
+  ordered_cache_behavior {
+    path_pattern = "/_csp"
+
+    allowed_methods        = ["GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH", "DELETE"]
+    cached_methods         = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id       = "rko-router-apprunner"
+    viewer_protocol_policy = "https-only"
+
+    cache_policy_id = data.aws_cloudfront_cache_policy.Managed-CachingDisabled.id
+  }
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    cached_methods         = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id       = "rko-router-apprunner"
+    viewer_protocol_policy = "allow-all"
+
+    cache_policy_id = aws_cloudfront_cache_policy.rko-router-default.id
+
+    compress = true
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.rko-router-viewreq.arn
+    }
+  }
+}
+
+data "aws_cloudfront_cache_policy" "Managed-CachingDisabled" {
+  name = "Managed-CachingDisabled"
+}
+
+resource "aws_cloudfront_cache_policy" "rko-router-default" {
+  name    = "rko-router-default"
+  comment = "rko-router-default"
+
+  min_ttl     = 1
+  default_ttl = 86400
+  max_ttl     = 31536000
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    headers_config {
+      header_behavior = "whitelist"
+      headers {
+        items = ["x-rko-host", "x-rko-xfp"]
+      }
+    }
+    query_strings_config {
+      query_string_behavior = "none"
+    }
+    cookies_config {
+      cookie_behavior = "none"
+    }
+  }
+}
+resource "null_resource" "tsc" {
+  triggers = {
+    tsdgst = join("", [
+      sha256(join("", [for f in fileset("${path.module}/cf_functions", "src/**/*.ts") : filesha256("${path.module}/cf_functions/${f}")])),
+      filesha256("${path.module}/cf_functions/package-lock.json"),
+    ])
+  }
+  provisioner "local-exec" {
+    command = "cd ${path.module}/cf_functions && npm i && tsc -b"
+  }
+}
+
+resource "aws_cloudfront_function" "rko-router-viewreq" {
+  name    = "rko-router-viewreq"
+  comment = "rko-router viewer-request"
+  runtime = "cloudfront-js-1.0"
+  publish = true
+  code    = file("${path.module}/cf_functions/src/viewreq.js")
+
+  depends_on = [null_resource.tsc]
+}
+

--- a/tf/versions.tf
+++ b/tf/versions.tf
@@ -3,6 +3,10 @@ terraform {
     aws = {
       source = "hashicorp/aws"
     }
+    null = {
+      source = "hashicorp/null"
+    }
   }
   required_version = ">= 0.13"
 }
+provider "null" {}


### PR DESCRIPTION
default server and x-rko-host mechanism, which was originally introduced for testing, is now also used in App Runner & CloudFront deployment. This is due to the quota of custom domains per App Runner service.

CloudFront function is used for assigning x-rko-host before forwarding to the origin on App Runner.

https://github.com/ruby-no-kai/rko-router/issues/81