### PR TITLE
fix http redirection on App Runner

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 .terraform/
 .github/
+node_modules/
+/tf/

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+config/*.conf linguist-language=nginx
+config/*.erb linguist-language=nginx

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # rubykaigi.org router
 
+nginx container deployed on AWS App Runner and served through CloudFront.
+
 ## Deploy
 
-Deployed on AWS App Runner and served through CloudFront. Deployments are automatically performed on GitHub Actions on `master` branch after CI.
+Deployments are automatically performed on GitHub Actions on `master` branch after CI.
 
 - App Runner: [arn:aws:apprunner:ap-northeast-1:005216166247:service/rko-router/259d1a5f750f4308a6c3ec8caede6d84](https://ap-northeast-1.console.aws.amazon.com/apprunner/home?region=ap-northeast-1#/services/dashboard?service_arn=arn%3Aaws%3Aapprunner%3Aap-northeast-1%3A005216166247%3Aservice%2Frko-router%2F259d1a5f750f4308a6c3ec8caede6d84&active_tab=logs)
 - CloudFront: [arn:aws:cloudfront::005216166247:distribution/E2WEWQCYU12GVD](https://us-east-1.console.aws.amazon.com/cloudfront/v3/home?region=ap-northeast-1#/distributions/E2WEWQCYU12GVD)
@@ -25,7 +27,7 @@ docker run --rm --name rko-router --publish 127.0.0.1::8080 rko-router:latest
 ```
 
 ```
-curl -H Host:rubykaigi.org http://localhost:$(docker port rko-router 8080)/
+curl -H Host:rubykaigi.org http://$(docker port rko-router 8080)/
 ```
 
 ## Test

--- a/config/force_https.conf
+++ b/config/force_https.conf
@@ -1,3 +1,6 @@
 if ($http_x_forwarded_proto = "http") {
   rewrite ^(.*)$ https://$http_host$1 permanent;
 }
+proxy_redirect http://rubykaigi.org https://rubykaigi.org;
+proxy_redirect https://2009-2011.rubykaigi.org https://rubykaigi.org;
+proxy_redirect https://gh-pages.rubykaigi.org https://rubykaigi.org;

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -304,22 +304,22 @@ http {
 
     location ~ ^/200[6-9] {
         include force_https.conf;
-        proxy_pass http://2009-2011.rubykaigi.org;
+        proxy_pass https://2009-2011.rubykaigi.org;
     }
 
     location ~ ^/201[0-9](.*) {
         include force_https.conf;
-        proxy_pass http://2009-2011.rubykaigi.org;
+        proxy_pass https://2009-2011.rubykaigi.org;
     }
 
     location /2020 {
         include force_https.conf;
-        proxy_pass http://2009-2011.rubykaigi.org;
+        proxy_pass https://2009-2011.rubykaigi.org;
     }
 
     location /2020-takeout {
         include force_https.conf;
-        proxy_pass http://2009-2011.rubykaigi.org;
+        proxy_pass https://2009-2011.rubykaigi.org;
     }
 
     location /2021 {
@@ -333,11 +333,11 @@ http {
 
     location /2021-takeout {
         include force_https.conf;
-        proxy_pass http://2009-2011.rubykaigi.org;
+        proxy_pass https://2009-2011.rubykaigi.org;
     }
 
     location ~ ^/\.2007(.*) {
-        proxy_pass http://2009-2011.rubykaigi.org;
+        proxy_pass https://2009-2011.rubykaigi.org;
     }
 
     # current rubykaigi

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -323,7 +323,7 @@ http {
     }
 
     location /2021 {
-      rewrite ^/2021/?$ https://rubykaigi.org/2021-takeout redirect;
+      rewrite ^/2021/?$ https://rubykaigi.org/2021-takeout/ redirect;
     }
 
     location ~ ^/202[2-3] {

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -104,6 +104,9 @@ http {
       if ( $x_rko_xfp = "" ) {
         set $x_rko_xfp "$http_x_forwarded_proto";
       }
+      if ( $x_rko_xfp = "" ) {
+        set $x_rko_xfp "http";
+      }
 
       proxy_set_header Host $http_x_rko_host;
       proxy_set_header X-Forwarded-Proto $x_rko_xfp;

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -342,7 +342,7 @@ http {
 
     # current rubykaigi
     location = / {
-        return 302 https://rubykaigi.org/2022;
+        return 302 https://rubykaigi.org/2022/;
     }
   }
 

--- a/spec/rubykaigi_org_spec.rb
+++ b/spec/rubykaigi_org_spec.rb
@@ -131,7 +131,7 @@ describe "http://rubykaigi.org" do
     end
 
     context "http" do
-      let(:res) { http_get("https://rubykaigi.org/2019/", proto: 'http') }
+      let(:res) { http_get("http://rubykaigi.org/2019/") }
       it "should force https" do
         expect(res.code).to eq("301")
         expect(res["location"]).to eq("https://rubykaigi.org/2019/")

--- a/spec/rubykaigi_org_spec.rb
+++ b/spec/rubykaigi_org_spec.rb
@@ -19,6 +19,22 @@ describe "http://rubykaigi.org" do
     end
   end
 
+  describe "(http) /2021" do
+    let(:res) { http_get("http://rubykaigi.org/2021") }
+    it "redirects to 2021-takeout" do
+      expect(res.code).to eq("302")
+      expect(res["location"]).to eq("https://rubykaigi.org/2021-takeout/")
+    end
+  end
+
+  describe "(https) /2021" do
+    let(:res) { http_get("https://rubykaigi.org/2021") }
+    it "redirects to 2021-takeout" do
+      expect(res.code).to eq("302")
+      expect(res["location"]).to eq("https://rubykaigi.org/2021-takeout/")
+    end
+  end
+
   describe "/2013/" do
     let(:res) { http_get("https://rubykaigi.org/2013/") }
     it "should render the top page" do

--- a/spec/rubykaigi_org_spec.rb
+++ b/spec/rubykaigi_org_spec.rb
@@ -3,19 +3,19 @@ require_relative "./spec_helper"
 describe "http://rubykaigi.org" do
   let(:latest_year) { "2022" }
 
-  describe "/" do
-    let(:res) { http_get("http://rubykaigi.org/") }
-    it "redirects to /?locale=en" do
+  describe "(https) /" do
+    let(:res) { http_get("https://rubykaigi.org/") }
+    it "redirects to latest_year" do
       expect(res.code).to eq("302")
-      expect(res["location"]).to eq("https://rubykaigi.org/#{latest_year}")
+      expect(res["location"]).to eq("https://rubykaigi.org/#{latest_year}/")
     end
   end
 
-  describe "/?locale=en" do
-    let(:res) { http_get("http://rubykaigi.org/?locale=en") }
-    it "redirects to the latest" do
+  describe "(http) /" do
+    let(:res) { http_get("http://rubykaigi.org/") }
+    it "redirects to latest_year" do
       expect(res.code).to eq("302")
-      expect(res["location"]).to eq("https://rubykaigi.org/#{latest_year}")
+      expect(res["location"]).to eq("https://rubykaigi.org/#{latest_year}/")
     end
   end
 

--- a/spec/rubykaigi_org_spec.rb
+++ b/spec/rubykaigi_org_spec.rb
@@ -29,23 +29,34 @@ describe "http://rubykaigi.org" do
 
   [*(2006..2009), *(2014..2017)].each do |year|
     describe "/#{year}" do
-      let(:res) { http_get("http://rubykaigi.org/#{year}") }
+      let(:res) { http_get("https://rubykaigi.org/#{year}") }
       it "should return 301 for trailing slash" do
         expect(res.code).to eq("301")
-        expect(res['location']).to eq("http://rubykaigi.org/#{year}/")
+        expect(res['location']).to eq("https://rubykaigi.org/#{year}/")
       end
     end
 
-    describe "/#{year}/" do
-      let(:res) { http_get("http://rubykaigi.org/#{year}/") }
-      it "should be available" do
-        expect(res.code).to eq("200")
+    context "http" do
+      describe "/#{year}" do
+        let(:res) { http_get("http://rubykaigi.org/#{year}") }
+        it "should return 301 for https" do
+          expect(res.code).to eq("301")
+          expect(res['location']).to eq("https://rubykaigi.org/#{year}")
+        end
+      end
+
+      describe "/#{year}/" do
+        let(:res) { http_get("http://rubykaigi.org/#{year}/") }
+        it "should return 301 for https" do
+          expect(res.code).to eq("301")
+          expect(res['location']).to eq("https://rubykaigi.org/#{year}/")
+        end
       end
     end
   end
 
   describe "/2013/" do
-    let(:res) { http_get("http://rubykaigi.org/2013/") }
+    let(:res) { http_get("https://rubykaigi.org/2013/") }
     it "should render the top page" do
       expect(res.code).to eq("200")
       expect(res.body).to include("<title>RubyKaigi 2013, May 30 - Jun 1</title>")
@@ -53,7 +64,7 @@ describe "http://rubykaigi.org" do
   end
 
   describe "/2012/" do
-    let(:res) { http_get("http://rubykaigi.org/2012/") }
+    let(:res) { http_get("https://rubykaigi.org/2012/") }
     it "should render the special 200 (not 404) page" do
       expect(res.code).to eq("200")
       expect(res.body).to include("<title>RubyKaigi 2012: 404 Kaigi Not Found</title>")
@@ -61,15 +72,15 @@ describe "http://rubykaigi.org" do
   end
 
   describe "/2011" do
-    let(:res) { http_get("http://rubykaigi.org/2011") }
+    let(:res) { http_get("https://rubykaigi.org/2011") }
     it "redirects to /2011/" do
       expect(res.code).to eq("301")
-      expect(res["location"]).to eq("http://rubykaigi.org/2011/")
+      expect(res["location"]).to eq("https://rubykaigi.org/2011/")
     end
   end
 
   describe "/2011/" do
-    let(:res) { http_get("http://rubykaigi.org/2011/") }
+    let(:res) { http_get("https://rubykaigi.org/2011/") }
     it "should render the top page" do
       expect(res.code).to eq("200")
       expect(res.body).to include("<title>RubyKaigi 2011(July 16 - 18)</title>")
@@ -77,15 +88,15 @@ describe "http://rubykaigi.org" do
   end
 
   describe "/2010" do
-    let(:res) { http_get("http://rubykaigi.org/2010") }
+    let(:res) { http_get("https://rubykaigi.org/2010") }
     it "redirects to /2010/" do
       expect(res.code).to eq("301")
-      expect(res["location"]).to eq("http://rubykaigi.org/2010/")
+      expect(res["location"]).to eq("https://rubykaigi.org/2010/")
     end
   end
 
   describe "/2010/en/" do
-    let(:res) { http_get("http://rubykaigi.org/2010/en/") }
+    let(:res) { http_get("https://rubykaigi.org/2010/en/") }
     it "should render the top page" do
       expect(res.code).to eq("200")
       expect(res.body).to include("<title>RubyKaigi 2010, August 27-29</title>")
@@ -93,15 +104,15 @@ describe "http://rubykaigi.org" do
   end
 
   describe "/2009" do
-    let(:res) { http_get("http://rubykaigi.org/2009") }
+    let(:res) { http_get("https://rubykaigi.org/2009") }
     it "redirects to /2009/" do
       expect(res.code).to eq("301")
-      expect(res["location"]).to eq("http://rubykaigi.org/2009/")
+      expect(res["location"]).to eq("https://rubykaigi.org/2009/")
     end
   end
 
   describe "/2009/en/" do
-    let(:res) { http_get("http://rubykaigi.org/2009/en/") }
+    let(:res) { http_get("https://rubykaigi.org/2009/en/") }
     it "should render the top page" do
       expect(res.code).to eq("200")
       expect(res.body).to include("<title>RubyKaigi2009</title>")

--- a/spec/rubykaigi_org_spec.rb
+++ b/spec/rubykaigi_org_spec.rb
@@ -19,15 +19,14 @@ describe "http://rubykaigi.org" do
     end
   end
 
-  describe "/?locale=ja" do
-    let(:res) { http_get("http://rubykaigi.org/?locale=ja") }
-    it "redirects to the latest" do
-      expect(res.code).to eq("302")
-      expect(res["location"]).to eq("https://rubykaigi.org/#{latest_year}")
-    end
-  end
-
   [*(2006..2009), *(2014..2017)].each do |year|
+    describe "/#{year}/" do
+      let(:res) { http_get("https://rubykaigi.org/#{year}/") }
+      it "should be available" do
+        expect(res.code).to eq("200")
+      end
+    end
+
     describe "/#{year}" do
       let(:res) { http_get("https://rubykaigi.org/#{year}") }
       it "should return 301 for trailing slash" do

--- a/spec/support/http_client.rb
+++ b/spec/support/http_client.rb
@@ -3,9 +3,11 @@ require 'net/https'
 require 'uri'
 
 module Helpers
-  def http_get(url, proto: 'https')
+  def http_get(url)
     uri = URI.parse(url)
-    target = URI.parse(ENV.fetch('TARGET_HOST', url))
+
+    custom_target = ENV['TARGET_HOST']&.then { URI.parse(_1) }
+    target = custom_target || uri
 
     http = Net::HTTP.new(target.host, target.port)
     http.use_ssl = true if target.scheme == 'https'
@@ -14,7 +16,7 @@ module Helpers
       headers = {
         'Host' => target.host,
         'x-rko-host' => uri.host,
-        'x-rko-xfp' => proto,
+        'x-rko-xfp' => uri.scheme,
       }
       http.get(uri.path, headers)
     end


### PR DESCRIPTION
- update tests to test force_https behavior more precisely
- declare proxy_redirect to avoid redirecting to http:// url for force_https enabled paths
  - this would avoid the dance like https://rubykaigi.org/200x => http://rubykaigi.org/200x/ => https://rubykaigi.org/200x/.
    - gh-pages returns http URL for trailing slash redirection (why?)
  - Heroku may be doing something like this on their proxy layer, but App Runner does not.

https://github.com/ruby-no-kai/rko-router/issues/81