### PR TITLE
regional.rubykaigi.org もforce sslしたい

### DIFF
--- a/config/force_https.conf
+++ b/config/force_https.conf
@@ -4,3 +4,4 @@ if ($http_x_forwarded_proto = "http") {
 proxy_redirect http://rubykaigi.org https://rubykaigi.org;
 proxy_redirect https://2009-2011.rubykaigi.org https://rubykaigi.org;
 proxy_redirect https://gh-pages.rubykaigi.org https://rubykaigi.org;
+proxy_redirect https://regional-gh.rubykaigi.org https://regional.rubykaigi.org;


### PR DESCRIPTION
ruby-no-kai/official#443 の問題を解決したい


