### PR TITLE
"regional.rubykaigi.org もforce sslしたい" Redux

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -248,7 +248,7 @@ http {
 
     # regional.rubykaigi.org
     location / {
-      proxy_set_header Host regional-gh.rubykaigi.org;
+      include force_https.conf;
       proxy_pass https://regional-gh.rubykaigi.org;
     }
   }

--- a/spec/regional_rubykaigi_org_spec.rb
+++ b/spec/regional_rubykaigi_org_spec.rb
@@ -1,6 +1,14 @@
 require_relative "./spec_helper"
 
 describe "http://regional.rubykaigi.org" do
+  describe "(http) /" do
+    let(:res) { http_get("http://regional.rubykaigi.org/") }
+    it "redirects to https" do
+      expect(res.code).to eq("302")
+      expect(res["location"]).to eq("https://regional.rubykaigi.org/")
+    end
+  end
+
   %w(
     /
     /oedo03/

--- a/spec/regional_rubykaigi_org_spec.rb
+++ b/spec/regional_rubykaigi_org_spec.rb
@@ -32,7 +32,7 @@ describe "http://regional.rubykaigi.org" do
     /kwsk01/
   ).each do |path|
     describe(path) do
-      let(:res) { http_get("http://regional.rubykaigi.org#{path}") }
+      let(:res) { http_get("https://regional.rubykaigi.org#{path}") }
       it "returns ok" do
         pending 'kanrk05.herokuapp.com is down' if path == '/kansai05/'
         pending 'http://rubykaigi-hamamatsu.s3-website-ap-northeast-1.amazonaws.com/hamamatsu01/ returns C-T:application/javascript' if path == '/hamamatsu01/'
@@ -51,7 +51,7 @@ describe "http://regional.rubykaigi.org" do
     /okrk01/ ruby.okinawa
   ).each_slice(2) do |path, host|
     describe(path) do
-      let(:res) { http_get("http://regional.rubykaigi.org#{path}") }
+      let(:res) { http_get("https://regional.rubykaigi.org#{path}") }
       it "redirects to matsue.rubyist.net" do
         expect(res.code.to_i).to be_between(300, 399)
         expect(res["location"]).to include(host)

--- a/spec/regional_rubykaigi_org_spec.rb
+++ b/spec/regional_rubykaigi_org_spec.rb
@@ -4,7 +4,7 @@ describe "http://regional.rubykaigi.org" do
   describe "(http) /" do
     let(:res) { http_get("http://regional.rubykaigi.org/") }
     it "redirects to https" do
-      expect(res.code).to eq("302")
+      expect(res.code).to eq("301")
       expect(res["location"]).to eq("https://regional.rubykaigi.org/")
     end
   end


### PR DESCRIPTION
### 実現したいこと

* http://regional.rubykaigi.org -> https://regional.rubykaigi.org  #に転送されて、ruby-no-kai/regional.rubykaigi.org  の配下にあるGH pagesなコンテンツが表示されてほしい。
* 現状、`regional-gh.rubykaigi.org` の force ssl の ✅ は on にしています


### 現状

* ふんいきで #88 を足すだけでは rrk.org を force ssl するには足りなかった(雑にPRを投げてしまった…)
* その後、改めて https://rubykaigi.esa.io/posts/1241 に目を通してみた(仕組みの全容は掴めておりません。プロ仕様だ…)

### やったこと

* rk.org の設定のように `include force_https.conf;` すればいいのかなあと思ったけど、rrk.org は `'/'` → current のような転送はしていないので、コピペ改変では `regional_rubykaigi_org_spec.rb`はfailureになってしまった…

### ここで手詰まり

* @sorah のお知恵を拝借したく!!

