### PR TITLE
Bump aws-actions/configure-aws-credentials to v2 that uses Node.js 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           ruby-version: '3.1'
           bundler-cache: true
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: "us-west-2"
           role-skip-session-tagging: true
@@ -71,7 +71,7 @@ jobs:
     needs:
       - ci
     steps:
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: "us-west-2"
           role-skip-session-tagging: true


### PR DESCRIPTION
This eliminates the following warning:
"Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: aws-actions/configure-aws-credentials@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/."

e.g. https://github.com/ruby-no-kai/rko-router/actions/runs/5003764840