### PR TITLE
Bump awslabs/amazon-app-runner-deploy to v2 that uses Node.js 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           role-skip-session-tagging: true
           role-to-assume: "arn:aws:iam::005216166247:role/GhaRkoRouterDeploy"
           mask-aws-account-id: 'false' # only string works
-      - uses: awslabs/amazon-app-runner-deploy@2b1ceb5d474d3c882bef811b4a12745b486d8cd5
+      - uses: awslabs/amazon-app-runner-deploy@v2
         with:
           region: "us-west-2"
           service: "rko-router"
@@ -85,4 +85,3 @@ jobs:
           access-role-arn:  "arn:aws:iam::005216166247:role/AppraRkoRouter"
           wait-for-service-stability: true
           port: "8080"
-


### PR DESCRIPTION
This patch is very much similar to #96 (the upstream repo includes aggressive refactorings though https://github.com/awslabs/amazon-app-runner-deploy#v2-changes ).

This eliminates the following warning:
"Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: awslabs/amazon-app-runner-deploy@2b1ceb5d474d3c882bef811b4a12745b486d8cd5. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/."

e.g. https://github.com/ruby-no-kai/rko-router/actions/runs/5004717810