### PR TITLE
Add tokyu14

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -183,6 +183,13 @@ http {
     }
 
     #
+    # tokyu14, y6y
+    #
+    location ~ ^/tokyu14(.*) {
+      proxy_pass https://tokyurubykaigi.github.io/tokyu14;
+    }
+
+    #
     # tokyu13, y6y
     #
     location ~ ^/tokyu13(.*) {

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -186,7 +186,7 @@ http {
     # tokyu14, y6y
     #
     location ~ ^/tokyu14(.*) {
-      proxy_pass https://tokyurubykaigi.github.io/tokyu14;
+      return 301 ttps://tokyurubykaigi.github.io/tokyu14;
     }
 
     #


### PR DESCRIPTION
TokyuRuby会議14への転送設定を追加しました。

転送先: https://tokyurubykaigi.github.io/tokyu14/
開催issue: https://github.com/ruby-no-kai/official/issues/476 TokyuRuby 会議 14 の開催