### PR TITLE
Add osaka04

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -137,6 +137,11 @@ http {
       return 301 https://magazine.rubyist.net/articles/0039/0039-MetPragdaveAtAsakusarb.html;
     }
 
+    location /osaka04 {
+      include force_https.conf;
+      proxy_pass https://rubykansai.github.io;
+    }
+
     location /osaka03 {
       include force_https.conf;
       proxy_pass https://rubykansai.github.io;


### PR DESCRIPTION
大阪Ruby会議04の転送設定の追加をお願いします。
https://rubykansai.github.io/osaka04/