### PR TITLE
Temporarily ignore tests for /oedo(05|06|10)/

### DIFF
--- a/spec/regional_rubykaigi_org_spec.rb
+++ b/spec/regional_rubykaigi_org_spec.rb
@@ -38,6 +38,9 @@ describe "http://regional.rubykaigi.org" do
       it "returns ok" do
         pending 'kanrk05.herokuapp.com is down' if path == '/kansai05/'
         pending 'http://rubykaigi-hamamatsu.s3-website-ap-northeast-1.amazonaws.com/hamamatsu01/ returns C-T:application/javascript' if path == '/hamamatsu01/'
+        pending 'asakusa.github.io returns 301 (#110)' if path == '/oedo05/'
+        pending 'asakusa.github.io returns 301 (#110)' if path == '/oedo06/'
+        pending 'asakusa.github.io returns 301 (#110)' if path == '/oedo10/'
 
         expect(res.code).to eq("200")
         expect(res["content-type"]).to include("text/html")


### PR DESCRIPTION
Follow-up of https://github.com/ruby-no-kai/rko-router/pull/110.

asakusa.github.io has (unintentionally) moved to asakusa.rubyist.net. https://github.com/ruby-no-kai/rko-router/pull/110#issuecomment-2264721392