### PR TITLE
tokyo12: proxy_set_header Host $http_host

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -260,9 +260,10 @@ http {
       proxy_pass https://asakusarb.github.io;
     }
 
-    location ~ ^/tokyo12(.*) {
+    location /tokyo12 {
       include force_https.conf;
-      proxy_pass https://osyoyu.github.io;
+      proxy_pass https://osyoyu.github.io; # requires Host: regional.rubykaigi.org
+      proxy_set_header Host $http_host;
     }
 
     location ~ ^/tokyo11(.*) {


### PR DESCRIPTION
Follow-up of https://github.com/ruby-no-kai/rko-router/pull/110.

`https://regional.rubykaigi.org/tokyo12/` が 200 になる一方、 `https://regional.rubykaigi.org/tokyo12` (trailing slash なし) が `https://osyoyu.github.io/tokyo12/` への 302 になってしまうのを解消したいパッチです。 `osyoyu.github.io` はなるべく露出させたくない。

- trailing slash がない場合、trailing slash ありのパスに 302 するのは GitHub Pages の仕様
- そのときの Location が `osyoyu.github.io` になる（GitHub Pages は regional.rubykaigi.org からプロキシされていることを当然知らないから）

そこで……

- GitHub Pages の [custom domain](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site) に `regional.rubykaigi.org` を設定した
  - `CNAME` ファイルを置くやつ
  - なお verification は（当然）通していない
- すると GitHub Pages は `regional.rubykaigi.org` でホストされている前提の挙動になる
  - trailing slash なしのアクセス時の 302 の Location も `regional.rubykaigi.org` になる
  - (おまけ: baseUrl が `/tokyo12` から `/` になる)

ということなのですが、アクセス時に期待される Host ヘッダも `regional.rubykaigi.org` になるわけです。そこで proxy_set_header を指定する必要がある、という内容のパッチでした。