### PR TITLE
tokyo12: No proxy_set_header

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -262,8 +262,7 @@ http {
 
     location /tokyo12 {
       include force_https.conf;
-      proxy_pass https://osyoyu.github.io; # requires Host: regional.rubykaigi.org
-      proxy_set_header Host $http_host;
+      proxy_pass https://osyoyu.github.io;
     }
 
     location ~ ^/tokyo11(.*) {


### PR DESCRIPTION
https://github.com/ruby-no-kai/rko-router/pull/112 の変更、GitHub Pages 側が HTTPS だとうまくいかない気配があったので戻します……。