### PR TITLE
Host oedo05 at regional.r-k.o

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -255,7 +255,7 @@ http {
       return 301 http://matsue.rubyist.net/matrk07/;
     }
 
-    location ~ ^/oedo(0[5-8]|10)(.*) {
+    location ~ ^/oedo(0[6-8]|10)(.*) {
       include force_https.conf;
       proxy_pass https://asakusarb.github.io;
     }

--- a/spec/regional_rubykaigi_org_spec.rb
+++ b/spec/regional_rubykaigi_org_spec.rb
@@ -38,7 +38,6 @@ describe "http://regional.rubykaigi.org" do
       it "returns ok" do
         pending 'kanrk05.herokuapp.com is down' if path == '/kansai05/'
         pending 'http://rubykaigi-hamamatsu.s3-website-ap-northeast-1.amazonaws.com/hamamatsu01/ returns C-T:application/javascript' if path == '/hamamatsu01/'
-        pending 'asakusa.github.io returns 301 (#110)' if path == '/oedo05/'
         pending 'asakusa.github.io returns 301 (#110)' if path == '/oedo06/'
         pending 'asakusa.github.io returns 301 (#110)' if path == '/oedo10/'
 


### PR DESCRIPTION
過去のoedoのいくつかのサイトのカスタムドメイン設定がうまくいってない問題 https://github.com/ruby-no-kai/rko-router/pull/110#issuecomment-2264627864
の対応で、oedo05をregional.r-k.o に移動することにします。