### PR TITLE
Add kansai08

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -155,6 +155,11 @@ http {
       proxy_pass https://rubykansai.github.io;
     }
 
+    location /kansai08 {
+      include force_https.conf;
+      proxy_pass https://rubykansai.github.io;
+    }
+
     location ~ ^/kansai2017(.*) {
       proxy_pass https://rubykansai.github.io;
     }


### PR DESCRIPTION
関西Ruby会議08の転送設定の追加をお願いします。
https://rubykansai.github.io/kansai08/