### PR TITLE
Move tokyo12 page to tokyorubykaigi12 org

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -267,7 +267,7 @@ http {
 
     location /tokyo12 {
       include force_https.conf;
-      proxy_pass https://osyoyu.github.io;
+      proxy_pass https://tokyorubykaigi12.github.io;
     }
 
     location ~ ^/tokyo11(.*) {


### PR DESCRIPTION
https://regional.rubykaigi.org/tokyo12/ の裏側の GitHub Pages のリポジトリを osyoyu/tokyo12 から tokyorubykaigi12/tokyo12 に引っ越ししたいので proxy_pass 先を変更します。
現時点で https://osyoyu.github.io/tokyo12/ と https://tokyorubykaigi12.github.io/tokyo12/ の両方で同じコンテンツをホストしているのでいつマージしてもらっても大丈夫です。