### PR TITLE
add nagoya05

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -328,6 +328,12 @@ http {
       proxy_pass https://corocn.github.io;
     }
 
+    location /nagoya05 {
+      include force_https.conf;
+      proxy_redirect https://corocn.github.io/nagoya05 $map_request_proto://$http_host/nagoya05;
+      proxy_pass https://corocn.github.io;
+    }
+
     location /hokuriku01 {
       include force_https.conf;
       proxy_redirect https://hokurikurb.github.io/hokuriku01 $map_request_proto://$http_host/hokuriku01;


### PR DESCRIPTION
名古屋Ruby会議05 の設定を追加しました。

redirect to https://corocn.github.io/nagoya05/

ref: https://github.com/ruby-no-kai/official/issues/547